### PR TITLE
Add capability to dump SQL Views

### DIFF
--- a/src/Settings/Database.php
+++ b/src/Settings/Database.php
@@ -26,15 +26,31 @@ class Database
      */
     public function getTable(string $table): Table
     {
-        $configTables = $this->settings;
+        try {
+            return new Table($this->findInSettings($table));
+        } catch (InvalidArgumentException) {
+            throw new InvalidArgumentException("The table [$table] does not exist in config.");
+        }
+    }
 
-        foreach ($configTables as $name => $config) {
-            $pattern = str_replace(['*', '?'], ['(.*)', '.'], $name);
-            if (preg_match("/^$pattern$/i", $table)) {
-                return new Table($config);
+    public function getView(string $view): View
+    {
+        try {
+            return new View($this->findInSettings($view));
+        } catch (InvalidArgumentException) {
+            throw new InvalidArgumentException("The view [$view] does not exist in config.");
+        }
+    }
+
+    private function findInSettings(string $search): stdClass
+    {
+        foreach ($this->settings as $name => $config) {
+            $pattern = str_replace([ '*', '?' ], [ '(.*)', '.' ], $name);
+            if (preg_match("/^$pattern$/i", $search)) {
+                return $config;
             }
         }
 
-        throw new InvalidArgumentException("The table [$table] does not exist in config.");
+        throw new InvalidArgumentException("[$search] does not exist in config.");
     }
 }

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -24,10 +24,21 @@ class Settings
         return new Database($this->settings->database);
     }
 
-    public function findTable(string $table): ?Table
+    public function findTable(string $table): Table|null
     {
         try {
-            return $this->getDatabase()->getTable($table);
+            return $this->getDatabase()
+                        ->getTable($table);
+        } catch (InvalidArgumentException $exception) {
+            return null;
+        }
+    }
+
+    public function findView(string $view): View|null
+    {
+        try {
+            return $this->getDatabase()
+                        ->getView(($view));
         } catch (InvalidArgumentException $exception) {
             return null;
         }

--- a/src/Settings/View.php
+++ b/src/Settings/View.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Worksome\Foggy\Settings;
+
+use stdClass;
+
+/**
+ * The container for all of the settings for a view.
+ * None at the moment
+ */
+class View
+{
+    protected stdClass $settings;
+
+    public function __construct(stdClass $settings)
+    {
+        $this->settings = $settings;
+    }
+}


### PR DESCRIPTION
## Description

Following the example of existing code, this brings capability to include SQL views into the dump.

No additional settings was added in term of obfuscation for SQL views as it does not make much sense to do so.

## How was this tested ? 

- This was locally tested on it's own with a dummy database containing a view
- This was also locally tested with foggy-laravel